### PR TITLE
Changed the data type getUnreadMessageCount() and setUnreadMessageCou…

### DIFF
--- a/CometChat.d.ts
+++ b/CometChat.d.ts
@@ -788,12 +788,12 @@ export namespace CometChat {
         setConversationType(conversationType: string): void;
         setLastMessage(lastMessage: TextMessage | MediaMessage | CustomMessage | any): void;
         setConversationWith(conversationWith: User | Group): void;
-        setUnreadMessageCount(unreadMessageCount: number): void;
+        setUnreadMessageCount(unreadMessageCount: any): void;
         getConversationId(): string;
         getConversationType(): string;
         getLastMessage(): TextMessage | MediaMessage | CustomMessage | any;
         getConversationWith(): User | Group;
-        getUnreadMessageCount(): number;
+        getUnreadMessageCount(): any;
         constructor(conversationId: string, conversationType: string, lastMessage: TextMessage | MediaMessage | CustomMessage | any, conversationWith: User | Group, unreadMessageCount: number | any)
     }
 


### PR DESCRIPTION
While building an Angular application and using the Angular UI Chat kit, I was forced to use two different versions trying to fix the issue with the snippet below, as extracted from the terminal. I did some digging and realized that a particular component within the UI kit wasn't compiling because of the data type specified for these two [setUnreadMessageCount() and getUnreadMessageCount()] methods within the SDK.

`
ERROR in src/lib/cometchat-angular-ui-kit/src/lib/conversations-list/conversations-list.component.ts:100:72 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

100                     updatedConversation.setUnreadMessageCount(parseInt(conversation.getUnreadMessageCount()) + 1);
                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib/cometchat-angular-ui-kit/src/lib/conversations-list/conversations-list.component.ts:129:72 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

129                     updatedConversation.setUnreadMessageCount(parseInt(conversation.getUnreadMessageCount()) + 1);
                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib/cometchat-angular-ui-kit/src/lib/conversations-list/conversations-list.component.ts:245:68 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

245                 updatedConversation.setUnreadMessageCount(parseInt(conversation.getUnreadMessageCount()) + 1);
                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
`